### PR TITLE
Add method to get the current quorum size

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,11 @@ impl<Key: PartialOrd + Ord + Clone, Value: Clone + Eq + Hash> Accumulator<Key, V
     pub fn set_quorum_size(&mut self, new_size: usize) {
         self.quorum = new_size;
     }
+
+    /// Returns the current value for `quorum`.
+    pub fn get_quorum_size(&self) -> usize {
+        self.quorum
+    }
 }
 
 #[cfg(test)]
@@ -315,6 +320,6 @@ mod test {
         let mut accumulator: Accumulator<i32, u32> = Accumulator::with_capacity(2, 100);
         let random = random::<usize>();
         accumulator.set_quorum_size(random);
-        assert_eq!(random, accumulator.quorum);
+        assert_eq!(random, accumulator.get_quorum_size());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ impl<Key: PartialOrd + Ord + Clone, Value: Clone + Eq + Hash> Accumulator<Key, V
     /// Sets a new value for `quorum`.
     ///
     /// This has immediate effect, even for existing key-value entries.
-    pub fn set_quorum_size(&mut self, new_size: usize) {
+    pub fn set_quorum(&mut self, new_size: usize) {
         self.quorum = new_size;
     }
 
@@ -316,10 +316,10 @@ mod test {
     }
 
     #[test]
-    fn set_quorum_size() {
+    fn set_quorum() {
         let mut accumulator: Accumulator<i32, u32> = Accumulator::with_capacity(2, 100);
         let random = random::<usize>();
-        accumulator.set_quorum_size(random);
+        accumulator.set_quorum(random);
         assert_eq!(random, accumulator.quorum());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ impl<Key: PartialOrd + Ord + Clone, Value: Clone + Eq + Hash> Accumulator<Key, V
     }
 
     /// Returns the current value for `quorum`.
-    pub fn get_quorum_size(&self) -> usize {
+    pub fn quorum(&self) -> usize {
         self.quorum
     }
 }
@@ -320,6 +320,6 @@ mod test {
         let mut accumulator: Accumulator<i32, u32> = Accumulator::with_capacity(2, 100);
         let random = random::<usize>();
         accumulator.set_quorum_size(random);
-        assert_eq!(random, accumulator.get_quorum_size());
+        assert_eq!(random, accumulator.quorum());
     }
 }


### PR DESCRIPTION
This PR adds a method to get the current quorum size.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/accumulator/65)

<!-- Reviewable:end -->
