### PR TITLE
Upgrade to rust 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ os:
   - osx
 language: rust
 rust:
-  - 1.31.1
+  - stable
 sudo: false
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,12 @@ env:
   global:
     - RUST_BACKTRACE=1
     - PATH=$PATH:$HOME/.cargo/bin
-    - RUST_STABLE=1.28.0
-    - RUST_NIGHTLY=nightly-2018-07-07
-    - RUST_RUSTFMT=0.99.2
-    - RUST_CLIPPY=0.0.212
 os:
   - linux
   - osx
 language: rust
 rust:
-  - 1.28.0
-  - nightly-2018-07-07
+  - 1.31.1
 sudo: false
 branches:
   only:
@@ -22,22 +17,13 @@ cache:
 before_script:
   - curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh
   - bash cargo_install.sh cargo-prune;
-  - if [ "$TRAVIS_RUST_VERSION" = $RUST_NIGHTLY ] && [ "$TRAVIS_OS_NAME" = linux ]; then
-      bash cargo_install.sh rustfmt-nightly "$RUST_RUSTFMT";
-      bash cargo_install.sh clippy "$RUST_CLIPPY";
-    fi
+  - rustup component add rustfmt;
+  - rustup component add clippy;
 script:
-  - if [ "${TRAVIS_RUST_VERSION}" = "$RUST_STABLE" ]; then
-      (
-        set -x;
-        cargo test --release --verbose
-      );
-    elif [ "${TRAVIS_OS_NAME}" = linux ]; then
-      (
-        set -x;
-        cargo fmt -- --check &&
-        cargo clippy && cargo clippy --profile test
-      );
-    fi
+  - set -x;
+    cargo fmt -- --check &&
+    cargo clippy &&
+    cargo clippy --profile test &&
+    cargo test --release --verbose
 before_cache:
  - cargo prune

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ name = "accumulator"
 readme = "README.md"
 repository = "https://github.com/maidsafe/accumulator"
 version = "0.7.0"
+edition = "2018"
 
 [dependencies]
 lru_time_cache = "~0.7.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   global:
     RUST_BACKTRACE: 1
   matrix:
-    - RUST_TOOLCHAIN: 1.31.1
+    - RUST_TOOLCHAIN: stable
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   global:
     RUST_BACKTRACE: 1
   matrix:
-    - RUST_TOOLCHAIN: 1.28.0
+    - RUST_TOOLCHAIN: 1.31.1
 
 branches:
   only:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,6 @@
     non_shorthand_field_patterns,
     overflowing_literals,
     plugin_as_library,
-    private_no_mangle_fns,
-    private_no_mangle_statics,
     stable_features,
     unconditional_recursion,
     unknown_lints,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,9 +67,6 @@
 #[cfg(test)]
 extern crate rand;
 
-// MaidSafe crates
-extern crate lru_time_cache;
-
 use lru_time_cache::LruCache;
 use std::collections::HashSet;
 use std::hash::Hash;


### PR DESCRIPTION
* Upgrade compiler
* Switch to 2018 edition
* Fix compilation, fmt and clippy warnings
* Remove nightly from CI